### PR TITLE
Fix post TOC, tag pages, and topbar layout

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -55,29 +55,31 @@
       {% endif %}
     </div>
 
-    {% unless site.theme_mode %}
-      <button type="button" class="btn btn-link" aria-label="Switch Mode" id="mode-toggle">
-        <i class="fas fa-adjust fa-fw"></i>
+    <div class="d-flex align-items-center">
+      {% unless site.theme_mode %}
+        <button type="button" class="btn btn-link" aria-label="Switch Mode" id="mode-toggle">
+          <i class="fas fa-adjust fa-fw"></i>
+        </button>
+      {% endunless %}
+
+      <button type="button" id="search-trigger" class="btn btn-link" aria-label="Search">
+        <i class="fas fa-search fa-fw"></i>
       </button>
-    {% endunless %}
 
-    <button type="button" id="search-trigger" class="btn btn-link" aria-label="Search">
-      <i class="fas fa-search fa-fw"></i>
-    </button>
-
-    <search id="search" class="align-items-center ms-3 ms-lg-0">
-      <i class="fas fa-search fa-fw"></i>
-      <input
-        class="form-control"
-        id="search-input"
-        type="search"
-        aria-label="search"
-        autocomplete="off"
-        placeholder="{{ site.data.locales[include.lang].search.hint | capitalize }}..."
-      >
-    </search>
-    <button type="button" class="btn btn-link text-decoration-none" id="search-cancel">
-      {{- site.data.locales[include.lang].search.cancel -}}
-    </button>
+      <search id="search" class="align-items-center ms-3 ms-lg-0">
+        <i class="fas fa-search fa-fw"></i>
+        <input
+          class="form-control"
+          id="search-input"
+          type="search"
+          aria-label="search"
+          autocomplete="off"
+          placeholder="{{ site.data.locales[include.lang].search.hint | capitalize }}..."
+        >
+      </search>
+      <button type="button" class="btn btn-link text-decoration-none" id="search-cancel">
+        {{- site.data.locales[include.lang].search.cancel -}}
+      </button>
+    </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- Enable TOC for blog posts via `toc: true` in post defaults (`_config.yml`)
- Add `jekyll-archives` gem to generate `/tags/<name>/` and `/categories/<name>/` pages — fixes broken tag links
- Group mode toggle and search controls together in topbar — removes the large gap between them

## Test plan
- [x] TOC panel renders on Kafka post with all section headings
- [x] `/tags/kafka/` resolves and lists matching posts
- [x] Mode toggle sits immediately left of the search icon in topbar