### PR TITLE
Increase avatar size to 12.5rem

### DIFF
--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,6 +1,6 @@
 <style>
   #avatar {
-    width: 9.5rem !important;
-    height: 9.5rem !important;
+    width: 12.5rem !important;
+    height: 12.5rem !important;
   }
 </style>

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -2,5 +2,11 @@
   #avatar {
     width: 12.5rem !important;
     height: 12.5rem !important;
+    overflow: hidden !important;
+  }
+  #avatar img {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: cover !important;
   }
 </style>


### PR DESCRIPTION
## Summary
- Bumped avatar from 9.5rem to 12.5rem in `_includes/metadata-hook.html`

## Test plan
- [x] Verified locally — avatar renders larger in sidebar