### PR TITLE
Replace ML with AI across site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ lang: en
 timezone: Asia/Singapore
 
 title: Srinivas Reddy Alluri
-tagline: Cloud Data/ML Engineering Lead
+tagline: Cloud Data/AI Engineering Lead
 description: Writing about data engineering, distributed systems, streaming pipelines, and machine learning at scale.
 
 url: "https://mrsrinivas.github.io"

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -3,14 +3,14 @@ icon: fas fa-info-circle
 order: 5
 ---
 
-I'm **Srinivas Reddy**, a Cloud Data/ML Engineering Lead with 12+ years of experience building large-scale data platforms, real-time streaming systems, and ML infrastructure.
+I'm **Srinivas Reddy**, a Cloud Data/AI Engineering Lead with 12+ years of experience building large-scale data platforms, real-time streaming systems, and AI infrastructure.
 
-Currently **Staff Software Engineer at Constantinople**, previously **Engineering Lead at Grab** (Southeast Asia's leading superapp) where I owned petabyte-scale data processing, real-time streaming with Kafka + Spark/Flink, ML feature stores, and self-serve tooling used by hundreds of data scientists across ride-hailing, food, and fintech.
+Currently **Staff Software Engineer at Constantinople**, previously **Engineering Lead at Grab** (Southeast Asia's leading superapp) where I owned petabyte-scale data processing, real-time streaming with Kafka + Spark/Flink, AI feature stores, and self-serve tooling used by hundreds of data scientists across ride-hailing, food, and fintech.
 
 ## What I work on
 
 - **Real-time pipelines** — Kafka, Spark Structured Streaming, Flink
-- **ML infrastructure** — Feature stores, model serving, experiment tracking, MLflow
+- **AI infrastructure** — Feature stores, model serving, experiment tracking, MLflow
 - **Cloud** — AWS (EMR, Glue, Redshift, Kinesis), GCP (BigQuery, Dataflow), Azure (ADF, Synapse)
 - **Data platforms** — Delta Lake, Apache Iceberg, dbt, Airflow
 - **Languages** — Python, Scala, SQL, Java

--- a/resume.html
+++ b/resume.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Srinivas Reddy Alluri | Cloud Data/ML Engineering Lead</title>
+  <title>Srinivas Reddy Alluri | Cloud Data/AI Engineering Lead</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700&display=swap">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
   <style>
@@ -210,7 +210,7 @@
 <div class="resume-container">
   <div class="resume-header">
     <h1>Srinivas Reddy Alluri</h1>
-    <h2>Cloud Data/ML Engineering Lead</h2>
+    <h2>Cloud Data/AI Engineering Lead</h2>
     <div class="contact-info">
       <a href="tel:+6582255712"><i class="fas fa-phone"></i> +65 82255712</a>
       | <a href="#"><i class="fas fa-envelope"></i> heysrini@outlook.com</a>
@@ -223,7 +223,7 @@
   <div class="resume-section">
     <h2><i class="fas fa-user"></i> Summary</h2>
     <ul>
-      <li><i class="fas fa-calendar-alt"></i> Accomplished Cloud Data/ML Solutions Lead with over a decade of experience in designing and
+      <li><i class="fas fa-calendar-alt"></i> Accomplished Cloud Data/AI Solutions Lead with over a decade of experience in designing and
         developing data/ml products and platforms for analytical consumers, adept in both cloud and on-premises
         environments.
       </li>
@@ -288,7 +288,7 @@
         </div>
         <div class="role-duration"><i class="fas fa-calendar-alt"></i> Oct 2019 – Mar 2025</div>
       </div>
-      <div class="role-summary">Led the Data Platform team within Grab’s DataTech org, managing 8+ engineers to build cloud-scale data and ML infrastructure powering analytics, experimentation, and business insights across Southeast Asia.</div>
+      <div class="role-summary">Led the Data Platform team within Grab’s DataTech org, managing 8+ engineers to build cloud-scale data and AI infrastructure powering analytics, experimentation, and business insights across Southeast Asia.</div>
 
       <h4><i class="fas fa-trophy"></i> Achievements</h4>
 
@@ -297,7 +297,7 @@
         <li>Developed a GenAI-powered analytics engine that generated actionable, user-friendly insights from billions of clickstream events, improving product team decision-making.</li>
         <li>Built a multi-tenant data platform that is used by 5 Grab subsidiaries by introducing a modular authorization framework that reduced access management overhead by 60%.</li>
         <li>Engineered a data quality validation system processing 5TB+ daily, increasing clickstream data accuracy by 30% and reducing incident rates.</li>
-        <li>Implemented a real-time feedback loop for ML pipelines, improving model reliability and reducing experiment cycle time by 25%.</li>
+        <li>Implemented a real-time feedback loop for AI pipelines, improving model reliability and reducing experiment cycle time by 25%.</li>
         <li>Directed the migration of a 1PB+ cloud data lake from AWS to Azure with zero downtime for analytics consumers.</li>
         <li>Reduced compute costs by 40% for experiment sample prediction by replacing full data scans with HyperLogLog and regression-based estimations.</li>
       </ul>
@@ -407,7 +407,7 @@
           <td>Python, Java, Scala, Go</td>
         </tr>
         <tr>
-          <td><i class="fas fa-cogs"></i> Data & ML Engineering</td>
+          <td><i class="fas fa-cogs"></i> Data & AI Engineering</td>
           <td>Apache Spark, Apache Kafka, Apache Flink, Apache Iceberg, Airflow, DBT, Databricks, Hadoop</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Summary
- `_config.yml`: tagline `Cloud Data/ML Engineering Lead` → `Cloud Data/AI Engineering Lead`
- `_tabs/about.md`: updated role title, infrastructure references
- `resume.html`: updated title, heading, summary, skills table
- AWS Certified Machine Learning – Specialty certification name left unchanged (official name)