### PR TITLE
Post: volatile vs static in Java — Thread Visibility Explained

### DIFF
--- a/_posts/2015-11-01-volatile-vs-static-in-java.md
+++ b/_posts/2015-11-01-volatile-vs-static-in-java.md
@@ -137,4 +137,3 @@ A good rule of thumb: if a variable is **written by one thread and read by other
 - **`static volatile`** = combine them freely. Class-level scope with full visibility guarantee.
 - **`volatile` + `++`** = still a race condition. Use `AtomicInteger` for thread-safe mutation.
 
-The short version from my [Stack Overflow answer](https://stackoverflow.com/a/33413884): `static` variables may be cached per thread. `volatile` forces threads to use the shared copy in main memory only.

--- a/_posts/2015-11-01-volatile-vs-static-in-java.md
+++ b/_posts/2015-11-01-volatile-vs-static-in-java.md
@@ -1,0 +1,140 @@
+---
+title: "volatile vs static in Java — Thread Visibility Explained"
+date: 2015-11-01 10:00:00 +0800
+categories: [Software Engineering, Java]
+tags: [java, concurrency, multithreading, jvm]
+---
+
+`static` and `volatile` both deal with shared data, but they solve completely different problems. Conflating them is one of the most common sources of subtle multithreading bugs in Java. This post explains exactly what each does, why the difference matters, and when to use each.
+
+## The Java Memory Model
+
+Modern CPUs do not read from RAM on every variable access — they maintain L1 and L2 caches per core to avoid the latency cost. The JVM is allowed to exploit this: it may keep a variable's value in a CPU register or cache instead of reading it from main memory on every access.
+
+This is a deliberate performance optimisation. It also means that two threads running on different CPU cores can hold **different values for the same variable** at the same time.
+
+![Java Memory Model — CPU caches per core](/assets/img/posts/volatile-vs-static-java/java-memory-model.svg){: width="760" height="490" }
+
+This is the Java Memory Model (JMM) in one picture. Main memory holds the authoritative value. Each CPU core has its own cache. Threads read from and write to their core's cache, not necessarily to main memory.
+
+## `static` — one instance, but threads can still cache it
+
+`static` is a **scope modifier**. A `static` variable belongs to the class, not to any instance. There is exactly one copy in the JVM, shared across all instances of that class.
+
+```java
+class Counter {
+    static int count = 0;  // one copy, shared by all instances
+}
+```
+
+What `static` does **not** do: it gives no guarantee about memory visibility across threads. The JVM may cache a `static` variable in a CPU register for performance. Thread 1 can update the value and Thread 2 may never see it, because Thread 2 is reading from its own core's cache.
+
+![static variable — Thread 2 reads a stale cached value](/assets/img/posts/volatile-vs-static-java/static-stale-read.svg){: width="700" height="370" }
+
+Thread 1 increments `counter` to 5. Thread 2 reads `counter` and gets 0. Thread 1's update never left its CPU cache, so Thread 2 has no way to observe it. Both threads are using the same `static` variable — they just each have a stale copy.
+
+## `volatile` — forces main memory visibility
+
+`volatile` is a **memory visibility modifier**. It instructs the JVM to never cache this variable. Every read goes directly to main memory. Every write is immediately flushed to main memory.
+
+```java
+class Server {
+    volatile boolean running = true;  // never cached, always from main memory
+
+    void shutdown() {
+        running = false;  // written directly to main memory
+    }
+
+    void run() {
+        while (running) {  // read directly from main memory on each iteration
+            // process work
+        }
+    }
+}
+```
+
+![volatile variable — both threads read from main memory](/assets/img/posts/volatile-vs-static-java/volatile-fresh-read.svg){: width="700" height="340" }
+
+Thread 1 sets `flag = true`. Because `flag` is `volatile`, this write goes directly to main memory. Thread 2 reads `flag` directly from main memory on every access. It immediately sees the update.
+
+`volatile` also establishes a **happens-before relationship**: anything Thread 1 did before writing to a `volatile` variable is guaranteed to be visible to Thread 2 after it reads that `volatile` variable.
+
+## `static volatile` — use both together
+
+`static` and `volatile` are orthogonal. `static` controls scope (class-level), `volatile` controls memory visibility. You can and often should combine them:
+
+```java
+class AppConfig {
+    private static volatile boolean debugMode = false;  // class-level + always visible
+
+    public static void enableDebug() {
+        debugMode = true;
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugMode;
+    }
+}
+```
+
+This is the correct pattern for a shared flag accessible across threads without creating an instance. `static` makes it class-level. `volatile` ensures every thread always reads the current value.
+
+The difference in plain terms:
+
+| | `static` | `volatile` |
+|---|---|---|
+| **What it does** | One instance per class | No CPU caching |
+| **Scope** | Class-level | N/A |
+| **Thread visibility** | Not guaranteed | Guaranteed |
+| **Atomicity** | No | No |
+| **Can combine** | Yes | Yes |
+
+## `volatile` does not mean atomic
+
+This is the most important limitation. `volatile` guarantees **visibility** but not **atomicity**. The classic trap is using `volatile` on a counter:
+
+```java
+volatile int counter = 0;
+counter++;  // looks atomic, is NOT
+```
+
+`counter++` compiles to three operations:
+
+1. **READ** — load the current value from main memory
+2. **INCREMENT** — add 1 to the local copy
+3. **WRITE** — store the result back to main memory
+
+Two threads can interleave these three operations and produce the wrong result:
+
+![volatile does not guarantee atomicity — counter++ race condition](/assets/img/posts/volatile-vs-static-java/volatile-not-atomic.svg){: width="700" height="360" }
+
+Both threads read `counter = 0`, both increment to 1, both write 1. The expected result is 2. You get 1. `volatile` prevented caching — both threads correctly saw `counter = 0` — but that only made the race condition more deterministic. It did not prevent it.
+
+For atomic operations, use `java.util.concurrent.atomic`:
+
+```java
+AtomicInteger counter = new AtomicInteger(0);
+counter.incrementAndGet();  // atomic read-modify-write, thread-safe
+```
+
+## When to use what
+
+| Scenario | Correct tool |
+|---|---|
+| Shared on/off flag between threads | `static volatile boolean` |
+| Shared singleton reference | `volatile` with double-checked locking |
+| Thread-safe counter | `AtomicInteger` |
+| Thread-safe compound operation | `synchronized` or `ReentrantLock` |
+| Thread-local state | `ThreadLocal<T>` |
+| Immutable shared state | `final` + safe publication |
+
+A good rule of thumb: if a variable is **written by one thread and read by others**, `volatile` is sufficient. If it is **read and written by multiple threads** (like a counter), you need atomics or synchronization.
+
+## Summary
+
+- **`static`** = one instance for all threads to share. Does not prevent per-CPU caching.
+- **`volatile`** = no caching, every read and write goes through main memory. Guarantees visibility, not atomicity.
+- **`static volatile`** = combine them freely. Class-level scope with full visibility guarantee.
+- **`volatile` + `++`** = still a race condition. Use `AtomicInteger` for thread-safe mutation.
+
+The short version from my [Stack Overflow answer](https://stackoverflow.com/a/33413884): `static` variables may be cached per thread. `volatile` forces threads to use the shared copy in main memory only.

--- a/assets/img/posts/volatile-vs-static-java/java-memory-model.svg
+++ b/assets/img/posts/volatile-vs-static-java/java-memory-model.svg
@@ -1,0 +1,69 @@
+<svg width="760" height="490" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7f8c8d"/>
+    </marker>
+    <marker id="arr-rev" markerWidth="10" markerHeight="7" refX="1" refY="3.5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7f8c8d"/>
+    </marker>
+  </defs>
+
+  <rect width="760" height="490" fill="#f8f9fa"/>
+
+  <!-- Main Memory -->
+  <rect x="130" y="20" width="500" height="108" rx="8" fill="#2c3e50"/>
+  <text x="380" y="44" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#ecf0f1">Main Memory (Heap)</text>
+  <line x1="140" y1="52" x2="620" y2="52" stroke="#7f8c8d" stroke-width="1"/>
+  <text x="200" y="74" font-family="monospace" font-size="12" fill="#bdc3c7">static int counter = 0;</text>
+  <text x="200" y="96" font-family="monospace" font-size="12" fill="#3498db">volatile boolean flag = false;</text>
+  <text x="200" y="116" font-family="sans-serif" font-size="10" fill="#7f8c8d">volatile is always read from and written to here, never cached</text>
+
+  <!-- Arrows: Main Memory to CPU cores (bidirectional) -->
+  <line x1="268" y1="128" x2="220" y2="178" stroke="#95a5a6" stroke-width="2" marker-start="url(#arr-rev)" marker-end="url(#arr)"/>
+  <line x1="492" y1="128" x2="540" y2="178" stroke="#95a5a6" stroke-width="2" marker-start="url(#arr-rev)" marker-end="url(#arr)"/>
+
+  <!-- CPU Core 1 -->
+  <rect x="60" y="178" width="300" height="152" rx="8" fill="#3d566e"/>
+  <text x="210" y="200" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#bdc3c7">CPU Core 1</text>
+
+  <!-- L1 Cache 1 -->
+  <rect x="85" y="210" width="250" height="102" rx="5" fill="#e67e22"/>
+  <text x="210" y="232" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#6b2d00">L1 / L2 Cache</text>
+  <line x1="95" y1="238" x2="325" y2="238" stroke="#ca6f1e" stroke-width="1"/>
+  <text x="210" y="260" text-anchor="middle" font-family="monospace" font-size="12" fill="#2c3e50">counter = 5</text>
+  <text x="210" y="280" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#6b2d00">local cached copy</text>
+  <text x="210" y="298" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#6b2d00">may differ from main memory</text>
+
+  <!-- Arrow: Core 1 to Thread 1 -->
+  <line x1="210" y1="330" x2="210" y2="370" stroke="#95a5a6" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Thread 1 -->
+  <rect x="60" y="370" width="300" height="78" rx="8" fill="#2980b9"/>
+  <text x="210" y="396" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 1</text>
+  <text x="210" y="416" text-anchor="middle" font-family="monospace" font-size="11" fill="#d6eaf8">counter++;  // reads cache: 5</text>
+  <text x="210" y="435" text-anchor="middle" font-family="monospace" font-size="11" fill="#d6eaf8">            // cache now: 6</text>
+
+  <!-- CPU Core 2 -->
+  <rect x="400" y="178" width="300" height="152" rx="8" fill="#3d566e"/>
+  <text x="550" y="200" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#bdc3c7">CPU Core 2</text>
+
+  <!-- L1 Cache 2 -->
+  <rect x="425" y="210" width="250" height="102" rx="5" fill="#e67e22"/>
+  <text x="550" y="232" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#6b2d00">L1 / L2 Cache</text>
+  <line x1="435" y1="238" x2="665" y2="238" stroke="#ca6f1e" stroke-width="1"/>
+  <text x="550" y="260" text-anchor="middle" font-family="monospace" font-size="12" fill="#2c3e50">counter = 0</text>
+  <text x="550" y="280" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#6b2d00">stale cached copy</text>
+  <text x="550" y="298" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#6b2d00">unaware of Thread 1 update</text>
+
+  <!-- Arrow: Core 2 to Thread 2 -->
+  <line x1="550" y1="330" x2="550" y2="370" stroke="#95a5a6" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Thread 2 -->
+  <rect x="400" y="370" width="300" height="78" rx="8" fill="#c0392b"/>
+  <text x="550" y="396" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 2</text>
+  <text x="550" y="416" text-anchor="middle" font-family="monospace" font-size="11" fill="#fadbd8">print(counter); // reads cache</text>
+  <text x="550" y="435" text-anchor="middle" font-family="monospace" font-size="11" fill="#fadbd8">// prints 0, expects 5!</text>
+
+  <!-- Caption -->
+  <text x="380" y="478" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#7f8c8d">Each CPU core may hold its own cached copy — static variables are not immune to this</text>
+</svg>

--- a/assets/img/posts/volatile-vs-static-java/static-stale-read.svg
+++ b/assets/img/posts/volatile-vs-static-java/static-stale-read.svg
@@ -1,0 +1,61 @@
+<svg width="700" height="370" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7f8c8d"/>
+    </marker>
+    <marker id="arr-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#c0392b"/>
+    </marker>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#27ae60"/>
+    </marker>
+  </defs>
+
+  <rect width="700" height="370" fill="#f8f9fa"/>
+
+  <!-- Main Memory -->
+  <rect x="200" y="20" width="300" height="70" rx="8" fill="#2c3e50"/>
+  <text x="350" y="44" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#ecf0f1">Main Memory</text>
+  <line x1="210" y1="52" x2="490" y2="52" stroke="#7f8c8d" stroke-width="1"/>
+  <text x="350" y="74" text-anchor="middle" font-family="monospace" font-size="13" fill="#bdc3c7">static int counter = 0</text>
+
+  <!-- Arrow: Main Memory to Thread 1 cache (flush, partial) -->
+  <line x1="280" y1="90" x2="180" y2="150" stroke="#27ae60" stroke-width="2" marker-end="url(#arr-green)"/>
+  <text x="175" y="122" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#27ae60">initial load</text>
+
+  <!-- Arrow: Main Memory to Thread 2 cache -->
+  <line x1="420" y1="90" x2="520" y2="150" stroke="#27ae60" stroke-width="2" marker-end="url(#arr-green)"/>
+  <text x="525" y="122" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#27ae60">initial load</text>
+
+  <!-- Thread 1 Cache -->
+  <rect x="40" y="150" width="240" height="100" rx="8" fill="#2980b9"/>
+  <text x="160" y="175" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 1</text>
+  <line x1="50" y1="183" x2="270" y2="183" stroke="#2471a3" stroke-width="1"/>
+  <text x="160" y="208" text-anchor="middle" font-family="monospace" font-size="14" fill="white">counter = 5</text>
+  <text x="160" y="230" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#aed6f1">updated locally, not flushed</text>
+
+  <!-- Thread 2 Cache -->
+  <rect x="420" y="150" width="240" height="100" rx="8" fill="#c0392b"/>
+  <text x="540" y="175" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 2</text>
+  <line x1="430" y1="183" x2="650" y2="183" stroke="#a93226" stroke-width="1"/>
+  <text x="540" y="208" text-anchor="middle" font-family="monospace" font-size="14" fill="white">counter = 0</text>
+  <text x="540" y="230" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#f1948a">stale! never saw update</text>
+
+  <!-- No flush arrow (crossed) -->
+  <line x1="290" y1="200" x2="410" y2="200" stroke="#7f8c8d" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="350" y="195" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#7f8c8d">no sync</text>
+
+  <!-- Thread 2 reads stale -->
+  <rect x="420" y="280" width="240" height="60" rx="8" fill="#e8daef" stroke="#c0392b" stroke-width="2"/>
+  <text x="540" y="305" text-anchor="middle" font-family="monospace" font-size="12" fill="#c0392b">if (counter == 5) ...</text>
+  <text x="540" y="325" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#c0392b">reads 0 — condition false!</text>
+
+  <line x1="540" y1="250" x2="540" y2="278" stroke="#c0392b" stroke-width="2" marker-end="url(#arr-red)"/>
+
+  <!-- Error label -->
+  <rect x="590" y="195" width="80" height="24" rx="4" fill="#c0392b"/>
+  <text x="630" y="211" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="white">STALE READ</text>
+
+  <!-- Caption -->
+  <text x="350" y="357" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#7f8c8d">Thread 1 updates its local cache but the change never reaches Thread 2</text>
+</svg>

--- a/assets/img/posts/volatile-vs-static-java/volatile-fresh-read.svg
+++ b/assets/img/posts/volatile-vs-static-java/volatile-fresh-read.svg
@@ -1,0 +1,62 @@
+<svg width="700" height="340" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#27ae60"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2980b9"/>
+    </marker>
+    <marker id="arr-rev-green" markerWidth="10" markerHeight="7" refX="1" refY="3.5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#27ae60"/>
+    </marker>
+  </defs>
+
+  <rect width="700" height="340" fill="#f8f9fa"/>
+
+  <!-- Main Memory -->
+  <rect x="200" y="20" width="300" height="80" rx="8" fill="#1a6b3a"/>
+  <text x="350" y="46" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#ecf0f1">Main Memory</text>
+  <line x1="210" y1="54" x2="490" y2="54" stroke="#148f54" stroke-width="1"/>
+  <text x="350" y="76" text-anchor="middle" font-family="monospace" font-size="13" fill="#a9dfbf">volatile boolean flag = true</text>
+  <text x="350" y="94" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#76b891">single authoritative source</text>
+
+  <!-- Thread 1 writes directly -->
+  <line x1="280" y1="100" x2="180" y2="165" stroke="#27ae60" stroke-width="2.5" marker-end="url(#arr-green)"/>
+  <text x="160" y="132" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#27ae60">write directly</text>
+  <text x="160" y="145" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#27ae60">to main memory</text>
+
+  <!-- Thread 2 reads directly -->
+  <line x1="420" y1="100" x2="520" y2="165" stroke="#2980b9" stroke-width="2.5" marker-end="url(#arr-blue)"/>
+  <text x="540" y="132" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#2980b9">read directly</text>
+  <text x="540" y="145" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#2980b9">from main memory</text>
+
+  <!-- Thread 1 -->
+  <rect x="40" y="165" width="240" height="110" rx="8" fill="#27ae60"/>
+  <text x="160" y="191" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 1</text>
+  <line x1="50" y1="199" x2="270" y2="199" stroke="#1e8449" stroke-width="1"/>
+  <text x="160" y="222" text-anchor="middle" font-family="monospace" font-size="11" fill="white">flag = true;</text>
+  <text x="160" y="243" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#d5f5e3">writes directly to main memory</text>
+  <text x="160" y="261" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#d5f5e3">no local cache for volatile</text>
+
+  <!-- No cache symbol on Thread 1 -->
+  <rect x="50" y="270" width="180" height="1" fill="#1e8449"/>
+
+  <!-- Thread 2 -->
+  <rect x="420" y="165" width="240" height="110" rx="8" fill="#2980b9"/>
+  <text x="540" y="191" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="white">Thread 2</text>
+  <line x1="430" y1="199" x2="650" y2="199" stroke="#2471a3" stroke-width="1"/>
+  <text x="540" y="222" text-anchor="middle" font-family="monospace" font-size="11" fill="white">if (flag) { ... }</text>
+  <text x="540" y="243" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#d6eaf8">reads directly from main memory</text>
+  <text x="540" y="261" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#d6eaf8">always sees latest value</text>
+
+  <!-- Success result -->
+  <rect x="420" y="300" width="240" height="22" rx="6" fill="#d5f5e3" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="540" y="315" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#1e8449">flag = true — condition holds!</text>
+
+  <!-- Success label -->
+  <rect x="588" y="160" width="72" height="24" rx="4" fill="#27ae60"/>
+  <text x="624" y="176" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="white">VISIBLE</text>
+
+  <!-- Caption -->
+  <text x="350" y="330" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#7f8c8d">volatile bypasses all CPU caches — every read goes to main memory, every write is immediately visible</text>
+</svg>

--- a/assets/img/posts/volatile-vs-static-java/volatile-not-atomic.svg
+++ b/assets/img/posts/volatile-vs-static-java/volatile-not-atomic.svg
@@ -1,0 +1,72 @@
+<svg width="700" height="360" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7f8c8d"/>
+    </marker>
+    <marker id="arr-red" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#c0392b"/>
+    </marker>
+  </defs>
+
+  <rect width="700" height="360" fill="#f8f9fa"/>
+
+  <!-- Title -->
+  <text x="350" y="22" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#2c3e50">counter++ is NOT atomic — it is 3 separate operations</text>
+
+  <!-- Step boxes background -->
+  <rect x="30" y="35" width="300" height="30" rx="4" fill="#2980b9"/>
+  <text x="180" y="55" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="white">Thread 1</text>
+
+  <rect x="370" y="35" width="300" height="30" rx="4" fill="#c0392b"/>
+  <text x="520" y="55" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="white">Thread 2</text>
+
+  <!-- Main memory bar -->
+  <rect x="270" y="35" width="160" height="30" rx="4" fill="#2c3e50"/>
+  <text x="350" y="55" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#ecf0f1">Main Memory</text>
+
+  <!-- Timeline rows -->
+  <!-- Row 1 -->
+  <rect x="30" y="80" width="300" height="44" rx="4" fill="#d6eaf8" stroke="#2980b9" stroke-width="1"/>
+  <text x="180" y="99" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#1a5276">Step 1: READ</text>
+  <text x="180" y="116" text-anchor="middle" font-family="monospace" font-size="11" fill="#1a5276">reads counter = 0</text>
+
+  <rect x="270" y="80" width="160" height="44" rx="4" fill="#eaecee" stroke="#7f8c8d" stroke-width="1"/>
+  <text x="350" y="107" text-anchor="middle" font-family="monospace" font-size="13" font-weight="bold" fill="#2c3e50">counter = 0</text>
+
+  <rect x="370" y="80" width="300" height="44" rx="4" fill="#fadbd8" stroke="#c0392b" stroke-width="1"/>
+  <text x="520" y="99" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#78281f">Step 1: READ</text>
+  <text x="520" y="116" text-anchor="middle" font-family="monospace" font-size="11" fill="#78281f">reads counter = 0</text>
+
+  <!-- Row 2 -->
+  <rect x="30" y="138" width="300" height="44" rx="4" fill="#d6eaf8" stroke="#2980b9" stroke-width="1"/>
+  <text x="180" y="157" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#1a5276">Step 2: INCREMENT</text>
+  <text x="180" y="174" text-anchor="middle" font-family="monospace" font-size="11" fill="#1a5276">local: 0 + 1 = 1</text>
+
+  <rect x="270" y="138" width="160" height="44" rx="4" fill="#eaecee" stroke="#7f8c8d" stroke-width="1"/>
+  <text x="350" y="165" text-anchor="middle" font-family="monospace" font-size="13" font-weight="bold" fill="#2c3e50">counter = 0</text>
+
+  <rect x="370" y="138" width="300" height="44" rx="4" fill="#fadbd8" stroke="#c0392b" stroke-width="1"/>
+  <text x="520" y="157" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#78281f">Step 2: INCREMENT</text>
+  <text x="520" y="174" text-anchor="middle" font-family="monospace" font-size="11" fill="#78281f">local: 0 + 1 = 1</text>
+
+  <!-- Row 3 -->
+  <rect x="30" y="196" width="300" height="44" rx="4" fill="#d6eaf8" stroke="#2980b9" stroke-width="1"/>
+  <text x="180" y="215" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#1a5276">Step 3: WRITE</text>
+  <text x="180" y="232" text-anchor="middle" font-family="monospace" font-size="11" fill="#1a5276">writes counter = 1</text>
+
+  <rect x="270" y="196" width="160" height="44" rx="4" fill="#eaecee" stroke="#7f8c8d" stroke-width="1"/>
+  <text x="350" y="223" text-anchor="middle" font-family="monospace" font-size="13" font-weight="bold" fill="#2c3e50">counter = 1</text>
+
+  <rect x="370" y="196" width="300" height="44" rx="4" fill="#fadbd8" stroke="#c0392b" stroke-width="1"/>
+  <text x="520" y="215" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#78281f">Step 3: WRITE</text>
+  <text x="520" y="232" text-anchor="middle" font-family="monospace" font-size="11" fill="#78281f">writes counter = 1 (overwrites!)</text>
+
+  <!-- Final result in main memory -->
+  <rect x="270" y="254" width="160" height="44" rx="4" fill="#c0392b"/>
+  <text x="350" y="275" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="white">RESULT</text>
+  <text x="350" y="292" text-anchor="middle" font-family="monospace" font-size="13" font-weight="bold" fill="white">counter = 1</text>
+
+  <!-- Expected vs actual -->
+  <text x="350" y="325" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#c0392b" font-weight="bold">Expected 2, got 1 — both threads incremented from 0</text>
+  <text x="350" y="348" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#7f8c8d">Use AtomicInteger.incrementAndGet() or synchronized for atomic operations</text>
+</svg>


### PR DESCRIPTION
## Summary
New blog post based on the Stack Overflow answer on volatile vs static in Java.

Covers static vs volatile with 4 original SVG diagrams: JMM overview, stale read problem, volatile solution, and atomicity limitation.

## Test plan
- [x] Verified locally — post renders with all 4 SVGs and TOC