### PR TITLE
Convert all SVG diagrams to Mermaid

### DIFF
--- a/_posts/2015-11-01-volatile-vs-static-in-java.md
+++ b/_posts/2015-11-01-volatile-vs-static-in-java.md
@@ -3,6 +3,7 @@ title: "volatile vs static in Java — Thread Visibility Explained"
 date: 2015-11-01 10:00:00 +0800
 categories: [Software Engineering, Java]
 tags: [java, concurrency, multithreading, jvm]
+mermaid: true
 ---
 
 `static` and `volatile` both deal with shared data, but they solve completely different problems. Conflating them is one of the most common sources of subtle multithreading bugs in Java. This post explains exactly what each does, why the difference matters, and when to use each.
@@ -13,7 +14,24 @@ Modern CPUs do not read from RAM on every variable access — they maintain L1 a
 
 This is a deliberate performance optimisation. It also means that two threads running on different CPU cores can hold **different values for the same variable** at the same time.
 
-![Java Memory Model — CPU caches per core](/assets/img/posts/volatile-vs-static-java/java-memory-model.svg){: width="760" height="490" }
+```mermaid
+graph TB
+    subgraph MM["Main Memory (Heap)"]
+        MV["static int counter = 0\nvolatile boolean flag = false\n— volatile is always read/written here, never cached —"]
+    end
+    subgraph Core1["CPU Core 1"]
+        C1["L1/L2 Cache\ncounter = 5\n(local copy, may differ from main memory)"]
+        T1["Thread 1\ncounter++\n// reads cache: 5 → cache now: 6"]
+        C1 --> T1
+    end
+    subgraph Core2["CPU Core 2"]
+        C2["L1/L2 Cache\ncounter = 0\n(stale — unaware of Thread 1 update)"]
+        T2["Thread 2\nprint(counter)\n// reads cache → prints 0, expects 5!"]
+        C2 --> T2
+    end
+    MM <-->|"write-back (may delay)"| C1
+    MM <-->|"read (may be stale)"| C2
+```
 
 This is the Java Memory Model (JMM) in one picture. Main memory holds the authoritative value. Each CPU core has its own cache. Threads read from and write to their core's cache, not necessarily to main memory.
 
@@ -29,7 +47,26 @@ class Counter {
 
 What `static` does **not** do: it gives no guarantee about memory visibility across threads. The JVM may cache a `static` variable in a CPU register for performance. Thread 1 can update the value and Thread 2 may never see it, because Thread 2 is reading from its own core's cache.
 
-![static variable — Thread 2 reads a stale cached value](/assets/img/posts/volatile-vs-static-java/static-stale-read.svg){: width="700" height="370" }
+```mermaid
+graph TB
+    subgraph MM["Main Memory"]
+        MV["static int counter = 0"]
+    end
+    subgraph T1Box["Thread 1 Cache (CPU Core 1)"]
+        C1["counter = 5\n(updated locally, not flushed)"]
+    end
+    subgraph T2Box["Thread 2 Cache (CPU Core 2)"]
+        C2["counter = 0\n(stale — never saw update)"]
+    end
+    R["Thread 2 reads: if (counter == 5) ...\n→ reads 0 — condition false! ❌  STALE READ"]
+
+    MM -->|"initial load"| C1
+    MM -->|"initial load"| C2
+    C2 --> R
+
+    style C2 fill:#fca5a5,color:#7f1d1d
+    style R fill:#fca5a5,color:#7f1d1d
+```
 
 Thread 1 increments `counter` to 5. Thread 2 reads `counter` and gets 0. Thread 1's update never left its CPU cache, so Thread 2 has no way to observe it. Both threads are using the same `static` variable — they just each have a stale copy.
 
@@ -53,7 +90,27 @@ class Server {
 }
 ```
 
-![volatile variable — both threads read from main memory](/assets/img/posts/volatile-vs-static-java/volatile-fresh-read.svg){: width="700" height="340" }
+```mermaid
+graph TB
+    subgraph MM["Main Memory"]
+        MV["volatile boolean flag = true\n(single authoritative source)"]
+    end
+    subgraph T1Box["Thread 1"]
+        T1["flag = true\n(writes directly to main memory\nno local cache for volatile)"]
+    end
+    subgraph T2Box["Thread 2"]
+        T2["if (flag) { ... }\n(reads directly from main memory\nalways sees latest value)"]
+        R["flag = true — condition holds! ✓  VISIBLE"]
+        T2 --> R
+    end
+
+    T1 -->|"write directly to main memory"| MM
+    MM -->|"read directly from main memory"| T2
+
+    style R fill:#bbf7d0,color:#14532d
+    style T1Box fill:#dcfce7
+    style T2Box fill:#dbeafe
+```
 
 Thread 1 sets `flag = true`. Because `flag` is `volatile`, this write goes directly to main memory. Thread 2 reads `flag` directly from main memory on every access. It immediately sees the update.
 
@@ -106,7 +163,34 @@ counter++;  // looks atomic, is NOT
 
 Two threads can interleave these three operations and produce the wrong result:
 
-![volatile does not guarantee atomicity — counter++ race condition](/assets/img/posts/volatile-vs-static-java/volatile-not-atomic.svg){: width="700" height="360" }
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1
+    participant MM as Main Memory
+    participant T2 as Thread 2
+
+    Note over MM: counter = 0
+
+    rect rgb(219,234,254)
+        Note over T1,T2: Step 1 — READ
+        T1->>MM: reads counter = 0
+        T2->>MM: reads counter = 0
+    end
+    rect rgb(254,249,195)
+        Note over T1,T2: Step 2 — INCREMENT (local)
+        Note over T1: 0 + 1 = 1
+        Note over MM: counter = 0 (unchanged)
+        Note over T2: 0 + 1 = 1
+    end
+    rect rgb(254,226,226)
+        Note over T1,T2: Step 3 — WRITE
+        T1->>MM: writes counter = 1
+        T2->>MM: writes counter = 1 (overwrites!)
+    end
+
+    Note over MM: RESULT: counter = 1 ❌ (expected 2)
+    Note over T1,T2: Both incremented from 0 — one update lost
+```
 
 Both threads read `counter = 0`, both increment to 1, both write 1. The expected result is 2. You get 1. `volatile` prevented caching — both threads correctly saw `counter = 0` — but that only made the race condition more deterministic. It did not prevent it.
 

--- a/_posts/2017-12-10-spark-workers-executors-explained.md
+++ b/_posts/2017-12-10-spark-workers-executors-explained.md
@@ -3,6 +3,7 @@ title: "Spark Workers, Executors, and the Cluster Runtime — A Visual Guide"
 date: 2017-12-10 10:00:00 +0800
 categories: [Data Engineering, Spark]
 tags: [spark, distributed-systems, cluster-computing, yarn]
+mermaid: true
 ---
 
 Three terms — worker, worker instance, and executor — appear constantly in Spark documentation, conference talks, and configuration files. They are easy to conflate because they all refer to components that run on cluster machines. They are not the same thing, and understanding the distinction matters when sizing clusters, tuning memory, and diagnosing slow jobs.
@@ -11,7 +12,28 @@ Three terms — worker, worker instance, and executor — appear constantly in S
 
 In Spark Standalone mode there are two roles: a **Master** and one or more **Workers**. The Master is the cluster manager — it tracks available resources and assigns them to applications. Workers are the resource providers — they report their CPU and memory to the Master and spawn Executors when asked.
 
-![Spark Standalone cluster — Master, Workers, and Executors](/assets/img/posts/spark-workers-executors/spark-standalone-cluster.svg){: width="760" height="500" }
+```mermaid
+graph TB
+    D["Driver Program\n(SparkContext / DAGScheduler / TaskScheduler)"]
+
+    M["Master Node\n(Cluster Manager — assigns resources to apps)"]
+
+    subgraph W1["Worker Node 1"]
+        E1["Executor JVM 1\n● Task  ● Task  ○ idle"]
+        E2["Executor JVM 2\n● Task  ● Task  ● Task"]
+    end
+    subgraph W2["Worker Node 2"]
+        E3["Executor JVM 1\n● Task  ● Task  ● Task"]
+        E4["Executor JVM 2\n● Task  ● Task  ● Task"]
+    end
+    subgraph W3["Worker Node 3"]
+        E5["Executor JVM 1\n● Task  ● Task  ● Task"]
+        E6["Executor JVM 2\n● Task  ● Task  ● Task"]
+    end
+
+    D -->|"submits app"| M
+    M --> W1 & W2 & W3
+```
 
 A few things worth noting in this picture:
 
@@ -36,7 +58,28 @@ You can run multiple worker processes on a single machine, but there is rarely a
 
 This is the more interesting question. A Worker process can spawn **multiple Executor processes** — each one is a separate JVM — as long as the machine has sufficient CPU cores, memory, and storage.
 
-![Worker node — one worker process with multiple executor JVMs](/assets/img/posts/spark-workers-executors/worker-node-detail.svg){: width="700" height="360" }
+```mermaid
+graph TB
+    subgraph Machine["Physical / Virtual Machine"]
+        WP["Worker Process\n(1 per node — manages resources, spawns executors)"]
+
+        subgraph E1["Executor JVM 1  |  Heap: 4 GB  |  Cores: 3"]
+            T1A["● Task (running)"]
+            T1B["● Task (running)"]
+            T1C["○ (idle)"]
+        end
+        subgraph E2["Executor JVM 2  |  Heap: 4 GB  |  Cores: 3"]
+            T2A["● Task (running)"]
+            T2B["○ (idle)"]
+            T2C["○ (idle)"]
+        end
+        subgraph E3["Executor JVM 3  (not started yet)"]
+            E3N["spawned when workload demands\nand resources allow"]
+        end
+
+        WP --> E1 & E2 & E3
+    end
+```
 
 The number of executors running on a worker node at any point in time depends on two things:
 
@@ -67,7 +110,36 @@ val result = rdd1
 
 Spark's execution model turns this into a **DAG of RDD operations**, splits the DAG into **Stages** at shuffle boundaries, and breaks each stage into **Tasks** — one per RDD partition — that run in parallel on Executors.
 
-![Spark runtime — DAG, stages, and parallel task execution](/assets/img/posts/spark-workers-executors/spark-runtime-flow.svg){: width="760" height="510" }
+```mermaid
+flowchart TB
+    Code["Spark Application Code\nrdd1.join(rdd2).reduce(...).filter(...)"]
+
+    subgraph Driver["Driver / SparkContext"]
+        DAG["DAGScheduler — builds DAG, splits into stages"]
+        TSched["TaskScheduler — assigns tasks to executor slots"]
+        DAG --> TSched
+    end
+
+    subgraph Stages["Stages (sequential)"]
+        S1["Stage 1: rdd1.join(rdd2)\n🔀 shuffle boundary — data redistribution"]
+        S2["Stage 2: .reduce(...)\naggregation per partition"]
+        S3["Stage 3: .filter(...)\nnarrow transform, no shuffle needed"]
+        S1 --> S2 --> S3
+    end
+
+    subgraph Executors["Executors (parallel task execution)"]
+        EA["Executor A — Worker 1\nTask P0 | Task P1 | Task P2"]
+        EB["Executor B — Worker 2\nTask P3 | Task P4 | Task P5"]
+        EC["Executor C — Worker 3\nTask P6 | Task P7 | ○ idle"]
+    end
+
+    R["Results collected → Driver"]
+
+    Code --> Driver
+    Driver --> Stages
+    Stages --> Executors
+    Executors --> R
+```
 
 Walking through the diagram:
 

--- a/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
+++ b/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
@@ -25,7 +25,7 @@ Before routing decisions happen, a producer passes a message through a pipeline 
 
 ```mermaid
 flowchart TB
-    PR["ProducerRecord\n(topic, [partition], [key], value)"]
+    PR["ProducerRecord\nTopic | [Partition] | [Key] | Value"]
 
     subgraph internals["Producer Internals"]
         SER["Serializer"]
@@ -34,22 +34,21 @@ flowchart TB
         B1["Topic B / Partition 1\nBatch 0 | Batch 1 | Batch 2"]
         FAIL{"Fail?"}
         RETRY{"Retry?"}
+
         SER --> PART
         PART --> B0 & B1
+        FAIL -->|"Yes"| RETRY
+        RETRY -->|"Yes"| B0 & B1
     end
 
     BR[("Kafka Broker")]
-    META["Metadata"]
-    EXC(["Throw Exception"])
+    EXC["Throw Exception"]
 
-    PR --> SER
+    PR -->|"Send()"| SER
     B0 & B1 --> BR
-    BR -->|"success — return Metadata"| META
-    META --> PR
-    BR -->|"error"| FAIL
-    FAIL -->|"yes"| RETRY
-    RETRY --> B0 & B1
-    FAIL -->|"no"| EXC
+    BR -->|"When successful, return Metadata"| PR
+    BR --> FAIL
+    RETRY -->|"If can't retry, throw exception"| EXC
 ```
 
 A producer always targets a **topic**, never a partition directly. But every message lands in exactly one partition. The selection follows a strict priority chain:

--- a/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
+++ b/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
@@ -3,6 +3,7 @@ title: "Kafka Topics and Partitions — A Complete Guide"
 date: 2018-08-13 19:16:00 +0800
 categories: [Data Engineering, Messaging]
 tags: [kafka, distributed-systems, streaming, consumer-groups]
+mermaid: true
 ---
 
 Apache Kafka's power comes from a deceptively simple model: producers write messages to topics, consumers read from them. But the real machinery — ordering guarantees, parallel consumption, fault tolerance — all lives inside the partition. This post walks through the full picture, from producer routing decisions to offset management and rebalancing.
@@ -22,7 +23,21 @@ Partitions are the unit of:
 
 Before routing decisions happen, a producer passes a message through a pipeline of internal components — serializers, partitioner, and a per-partition record accumulator — before batching it to the broker.
 
-![Overview of producer components](/assets/img/posts/kafka-topics-partitions/producer-overview.svg){: width="760" height="710" }
+```mermaid
+flowchart LR
+    PR["ProducerRecord\n(topic, key, value)"]
+    SER["Serializer\n(key + value)"]
+    PART["Partitioner"]
+    B0["Partition 0\nBuffer"]
+    B1["Partition 1\nBuffer"]
+    B2["Partition 2\nBuffer"]
+    NET["Network Sender\n(batches)"]
+    BR["Broker"]
+
+    PR --> SER --> PART
+    PART --> B0 & B1 & B2
+    B0 & B1 & B2 --> NET --> BR
+```
 
 A producer always targets a **topic**, never a partition directly. But every message lands in exactly one partition. The selection follows a strict priority chain:
 
@@ -30,13 +45,26 @@ A producer always targets a **topic**, never a partition directly. But every mes
 2. **Key-based hashing** — if you provide a message key, Kafka computes `hash(key) % num_partitions`. The same key always routes to the same partition. This gives you **per-key ordering** — useful when all events for a given entity (user, order, device) must be processed in sequence.
 3. **Round-robin (or sticky)** — no partition, no key? Kafka distributes messages evenly across partitions. Modern clients use a *sticky* strategy — batching to one partition until the batch is full, then rotating — to improve throughput without sacrificing fairness.
 
-![Key-based producer routing](/assets/img/posts/kafka-topics-partitions/producer-key-routing.svg){: width="680" height="300" }
+```mermaid
+flowchart LR
+    P["Producer\n(key = 'user-42')"] --> H["Partitioner\nhash('user-42') % 3"]
+    H -->|"= 0"| P0["Partition 0"]
+    H -->|"= 1"| P1["Partition 1 ✓"]
+    H -->|"= 2"| P2["Partition 2"]
+    style P1 fill:#22c55e,color:#fff
+```
 
 The critical implication: **ordering is only guaranteed within a partition**. If you need strict global ordering across all messages, you're forced to use a single partition — which eliminates parallelism entirely. In practice, most systems choose a meaningful key (customer ID, device ID, entity ID) and accept per-key ordering as sufficient.
 
 **Round-robin** distributes messages evenly with no ordering guarantee — suited to high-throughput pipelines where per-message ordering doesn't matter.
 
-![Round-robin producer routing](/assets/img/posts/kafka-topics-partitions/producer-roundrobin.svg){: width="680" height="300" }
+```mermaid
+flowchart LR
+    P["Producer\n(no key)"] --> RR["Partitioner\n(sticky round-robin)"]
+    RR --> P0["Partition 0"]
+    RR --> P1["Partition 1"]
+    RR --> P2["Partition 2"]
+```
 
 ### Choosing Keys Wisely
 
@@ -64,19 +92,67 @@ Think of partitions as units of work and consumers as workers.
 
 Some consumers handle multiple partitions. Throughput is limited by the slowest consumer. This is a normal operating state — it still works, it just means some consumers carry more load.
 
-![Fewer consumers than partitions](/assets/img/posts/kafka-topics-partitions/fewer-consumers.svg){: width="620" height="320" }
+```mermaid
+flowchart LR
+    subgraph Topic["Topic (4 partitions)"]
+        P0["Partition 0"]
+        P1["Partition 1"]
+        P2["Partition 2"]
+        P3["Partition 3"]
+    end
+    subgraph Group["Consumer Group"]
+        C1["Consumer 1"]
+        C2["Consumer 2"]
+    end
+    P0 --> C1
+    P1 --> C1
+    P2 --> C2
+    P3 --> C2
+```
 
 ### Consumers equal partitions
 
 Clean 1:1 mapping. Each consumer owns exactly one partition. This is the ideal steady state for maximum parallelism with no idle capacity.
 
-![Equal consumers and partitions](/assets/img/posts/kafka-topics-partitions/equal-consumers.svg){: width="620" height="340" }
+```mermaid
+flowchart LR
+    subgraph Topic["Topic (3 partitions)"]
+        P0["Partition 0"]
+        P1["Partition 1"]
+        P2["Partition 2"]
+    end
+    subgraph Group["Consumer Group"]
+        C1["Consumer 1"]
+        C2["Consumer 2"]
+        C3["Consumer 3"]
+    end
+    P0 --> C1
+    P1 --> C2
+    P2 --> C3
+```
 
 ### More consumers than partitions
 
 The extra consumers sit idle. Kafka cannot split a single partition across multiple consumers within the same group — a partition is always owned by at most one consumer per group.
 
-![More consumers than partitions](/assets/img/posts/kafka-topics-partitions/more-consumers.svg){: width="620" height="390" }
+```mermaid
+flowchart LR
+    subgraph Topic["Topic (3 partitions)"]
+        P0["Partition 0"]
+        P1["Partition 1"]
+        P2["Partition 2"]
+    end
+    subgraph Group["Consumer Group"]
+        C1["Consumer 1"]
+        C2["Consumer 2"]
+        C3["Consumer 3"]
+        C4["Consumer 4 — idle"]
+    end
+    P0 --> C1
+    P1 --> C2
+    P2 --> C3
+    style C4 fill:#fca5a5,color:#7f1d1d
+```
 
 If you have 5 consumers and 4 partitions, the 5th consumer does nothing. Adding more consumers beyond partition count gives zero throughput benefit.
 

--- a/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
+++ b/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
@@ -26,8 +26,11 @@ Before routing decisions happen, a producer passes a message through a pipeline 
 ```mermaid
 flowchart TB
     PR["ProducerRecord\nTopic | [Partition] | [Key] | Value"]
+    BR[("Kafka Broker")]
+    EXC["Throw Exception"]
 
     subgraph internals["Producer Internals"]
+        direction TB
         SER["Serializer"]
         PART["Partitioner"]
         B0["Topic A / Partition 0\nBatch 0 | Batch 1 | Batch 2"]
@@ -36,18 +39,18 @@ flowchart TB
         RETRY{"Retry?"}
 
         SER --> PART
-        PART --> B0 & B1
+        PART --> B0
+        PART --> B1
+        B0 ~~~ B1
         FAIL -->|"Yes"| RETRY
-        RETRY -->|"Yes"| B0 & B1
     end
 
-    BR[("Kafka Broker")]
-    EXC["Throw Exception"]
-
     PR -->|"Send()"| SER
-    B0 & B1 --> BR
+    B0 --> BR
+    B1 --> BR
     BR -->|"When successful, return Metadata"| PR
     BR --> FAIL
+    RETRY -->|"Yes — re-enqueue"| B0
     RETRY -->|"If can't retry, throw exception"| EXC
 ```
 

--- a/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
+++ b/_posts/2018-08-13-kafka-topics-and-partitions-explained.md
@@ -24,19 +24,32 @@ Partitions are the unit of:
 Before routing decisions happen, a producer passes a message through a pipeline of internal components — serializers, partitioner, and a per-partition record accumulator — before batching it to the broker.
 
 ```mermaid
-flowchart LR
-    PR["ProducerRecord\n(topic, key, value)"]
-    SER["Serializer\n(key + value)"]
-    PART["Partitioner"]
-    B0["Partition 0\nBuffer"]
-    B1["Partition 1\nBuffer"]
-    B2["Partition 2\nBuffer"]
-    NET["Network Sender\n(batches)"]
-    BR["Broker"]
+flowchart TB
+    PR["ProducerRecord\n(topic, [partition], [key], value)"]
 
-    PR --> SER --> PART
-    PART --> B0 & B1 & B2
-    B0 & B1 & B2 --> NET --> BR
+    subgraph internals["Producer Internals"]
+        SER["Serializer"]
+        PART["Partitioner"]
+        B0["Topic A / Partition 0\nBatch 0 | Batch 1 | Batch 2"]
+        B1["Topic B / Partition 1\nBatch 0 | Batch 1 | Batch 2"]
+        FAIL{"Fail?"}
+        RETRY{"Retry?"}
+        SER --> PART
+        PART --> B0 & B1
+    end
+
+    BR[("Kafka Broker")]
+    META["Metadata"]
+    EXC(["Throw Exception"])
+
+    PR --> SER
+    B0 & B1 --> BR
+    BR -->|"success — return Metadata"| META
+    META --> PR
+    BR -->|"error"| FAIL
+    FAIL -->|"yes"| RETRY
+    RETRY --> B0 & B1
+    FAIL -->|"no"| EXC
 ```
 
 A producer always targets a **topic**, never a partition directly. But every message lands in exactly one partition. The selection follows a strict priority chain:
@@ -47,11 +60,25 @@ A producer always targets a **topic**, never a partition directly. But every mes
 
 ```mermaid
 flowchart LR
-    P["Producer\n(key = 'user-42')"] --> H["Partitioner\nhash('user-42') % 3"]
-    H -->|"= 0"| P0["Partition 0"]
-    H -->|"= 1"| P1["Partition 1 ✓"]
-    H -->|"= 2"| P2["Partition 2"]
-    style P1 fill:#22c55e,color:#fff
+    A["Record A\nkey='user:42'"]
+    B["Record B\nkey='user:42'"]
+    C["Record C\nkey='user:7'"]
+    H["hash(key) % num_partitions"]
+    P0["Partition 0\n(user:42 messages)"]
+    P1["Partition 1\n(user:7 messages)"]
+    P2["Partition 2\n(other keys)"]
+
+    A & B --> H
+    C --> H
+    H -->|"= 0 — same key, same partition"| P0
+    H -->|"= 1"| P1
+
+    style A fill:#3b82f6,color:#fff
+    style B fill:#3b82f6,color:#fff
+    style C fill:#a855f7,color:#fff
+    style P0 fill:#22c55e,color:#fff
+    style P1 fill:#f97316,color:#fff
+    style P2 fill:#9ca3af,color:#fff
 ```
 
 The critical implication: **ordering is only guaranteed within a partition**. If you need strict global ordering across all messages, you're forced to use a single partition — which eliminates parallelism entirely. In practice, most systems choose a meaningful key (customer ID, device ID, entity ID) and accept per-key ordering as sufficient.
@@ -60,10 +87,21 @@ The critical implication: **ordering is only guaranteed within a partition**. If
 
 ```mermaid
 flowchart LR
-    P["Producer\n(no key)"] --> RR["Partitioner\n(sticky round-robin)"]
-    RR --> P0["Partition 0"]
-    RR --> P1["Partition 1"]
-    RR --> P2["Partition 2"]
+    R1["Record 1\nkey=null"]
+    R2["Record 2\nkey=null"]
+    R3["Record 3\nkey=null"]
+    R4["Record 4\nkey=null"]
+    RR["Partitioner\n(round-robin: P0→P1→P2…)"]
+    P0["Partition 0\nmsg 1, msg 4…"]
+    P1["Partition 1\nmsg 2, msg 5…"]
+    P2["Partition 2\nmsg 3, msg 6…"]
+
+    R1 & R2 & R3 & R4 --> RR
+    RR --> P0 & P1 & P2
+
+    style P0 fill:#22c55e,color:#fff
+    style P1 fill:#f97316,color:#fff
+    style P2 fill:#a855f7,color:#fff
 ```
 
 ### Choosing Keys Wisely
@@ -116,19 +154,22 @@ Clean 1:1 mapping. Each consumer owns exactly one partition. This is the ideal s
 
 ```mermaid
 flowchart LR
-    subgraph Topic["Topic (3 partitions)"]
+    subgraph Topic["Topic T1 (4 partitions)"]
         P0["Partition 0"]
         P1["Partition 1"]
         P2["Partition 2"]
+        P3["Partition 3"]
     end
-    subgraph Group["Consumer Group"]
+    subgraph Group["Consumer Group 1"]
         C1["Consumer 1"]
         C2["Consumer 2"]
         C3["Consumer 3"]
+        C4["Consumer 4"]
     end
     P0 --> C1
     P1 --> C2
     P2 --> C3
+    P3 --> C4
 ```
 
 ### More consumers than partitions
@@ -137,21 +178,24 @@ The extra consumers sit idle. Kafka cannot split a single partition across multi
 
 ```mermaid
 flowchart LR
-    subgraph Topic["Topic (3 partitions)"]
+    subgraph Topic["Topic T1 (4 partitions)"]
         P0["Partition 0"]
         P1["Partition 1"]
         P2["Partition 2"]
+        P3["Partition 3"]
     end
-    subgraph Group["Consumer Group"]
+    subgraph Group["Consumer Group 1"]
         C1["Consumer 1"]
         C2["Consumer 2"]
         C3["Consumer 3"]
-        C4["Consumer 4 — idle"]
+        C4["Consumer 4"]
+        C5["Consumer 5\n(idle — no partition assigned)"]
     end
     P0 --> C1
     P1 --> C2
     P2 --> C3
-    style C4 fill:#fca5a5,color:#7f1d1d
+    P3 --> C4
+    style C5 fill:#d1d5db,color:#374151,stroke:#9ca3af,stroke-dasharray:5 5
 ```
 
 If you have 5 consumers and 4 partitions, the 5th consumer does nothing. Adding more consumers beyond partition count gives zero throughput benefit.


### PR DESCRIPTION
## Summary

Replaces all inline SVG image references across 3 posts with interactive Mermaid diagrams. Diagrams are built from the original SVG source files for accuracy.

### Kafka post (6 diagrams)
- Producer pipeline with retry/fail loop and metadata return path
- Key-based routing showing 3 input records with correct partition assignment
- Round-robin routing showing 4 records cycling across partitions
- Fewer consumers (4 partitions / 2 consumers)
- Equal consumers (4 partitions / 4 consumers — corrected from 3/3)
- More consumers (4 partitions / 5 consumers, idle highlighted — corrected from 3/4)

### Spark post (3 diagrams)
- Standalone cluster: Driver → Master → 3 Worker nodes with executor task slots
- Worker node detail: Worker process, 2 active JVMs with task slots, 1 pending executor
- Runtime flow: Application code → DAG/Task scheduler → 3 stages → 3 executors → results

### volatile/static Java post (4 diagrams)
- Java Memory Model: main memory + 2 CPU cores with caches
- Static stale read: Thread 1 updates cache, Thread 2 reads stale value
- Volatile fresh read: both threads go via main memory
- Not-atomic race condition: sequence diagram of READ/INCREMENT/WRITE interleaving

## Test plan
- [x] All 13 diagrams verified rendering in preview
- [x] Dark mode compatible (Mermaid renders natively)
- [x] `mermaid: true` added to each post's front matter