### PR TITLE
Pin topbar sticky while scrolling

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1,0 +1,17 @@
+---
+---
+
+/* prettier-ignore */
+@use 'main
+{%- if jekyll.environment == 'production' -%}
+  .bundle
+{%- endif -%}
+';
+
+/* Custom overrides */
+
+#topbar-wrapper {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}


### PR DESCRIPTION
## Summary

- Adds `assets/css/jekyll-theme-chirpy.scss` as a local CSS override file (Chirpy's intended customisation point)
- Sets `position: sticky; top: 0; z-index: 100` on `#topbar-wrapper` so the dark mode toggle and nav remain visible while scrolling through long posts

## Test plan

- [ ] Open a long post and scroll — topbar stays pinned at the top
- [ ] Dark mode toggle remains accessible throughout the page
- [ ] No layout regressions on mobile or desktop