### PR TITLE
Add Giscus comments and reactions to blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,18 @@ toc: true
 
 paginate: 10
 
+comments:
+  provider: giscus
+  giscus:
+    repo: mrsrinivas/mrsrinivas.github.io
+    repo_id: MDEwOlJlcG9zaXRvcnkzNzI0MzA4OA==
+    category: General
+    category_id: DIC_kwDOAjhI0M4C5iMa
+    mapping: url
+    strict: 1
+    reactions_enabled: 1
+    input_position: bottom
+
 markdown: kramdown
 highlighter: rouge
 kramdown:
@@ -57,7 +69,7 @@ defaults:
       type: posts
     values:
       layout: post
-      comments: false
+      comments: true
       toc: true
   - scope:
       path: ""


### PR DESCRIPTION
## Summary

- **Giscus comments** — GitHub Discussions-based comment box below every post; readers sign in with GitHub, reactions (👍 ❤️ 🎉 etc.) enabled; auto-syncs with dark/light mode toggle
- **GoatCounter analytics** — privacy-friendly, no cookie banner needed, tracks page views at \`sreddya.goatcounter.com\`
- **Per-post page view count** — live view count displayed on each post next to reading time (fetched from GoatCounter's public counter API)

## Config changes in `_config.yml`

- \`analytics.goatcounter.id: sreddya\`
- \`pageviews.provider: goatcounter\`
- \`comments.provider: giscus\` with repo/category IDs
- \`comments: true\` enabled by default for all posts

## Test plan

- [ ] Open a post — Giscus comment box appears below content
- [ ] Toggle dark mode — Giscus iframe theme updates accordingly
- [ ] Page view count appears next to reading time on posts
- [ ] GoatCounter dashboard at sreddya.goatcounter.com shows traffic after a visit
- [ ] GitHub Discussions enabled on repo (Settings → Features → Discussions)