### PR TITLE
Add GoatCounter analytics and per-post page view counts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,13 @@ toc: true
 
 paginate: 10
 
+analytics:
+  goatcounter:
+    id: sreddya
+
+pageviews:
+  provider: goatcounter
+
 comments:
   provider: giscus
   giscus:


### PR DESCRIPTION
## Summary

- Adds GoatCounter analytics (`sreddya.goatcounter.com`) — privacy-friendly, no cookie banner needed
- Enables per-post page view count shown next to reading time, fetched live from GoatCounter's public counter API

## Config changes in `_config.yml`

- `analytics.goatcounter.id: sreddya`
- `pageviews.provider: goatcounter`

## Test plan

- [ ] Visit a post — page view count appears next to reading time
- [ ] Check [sreddya.goatcounter.com](https://sreddya.goatcounter.com) dashboard shows traffic after a visit