### PR TITLE
Remove Chirpy theme attribution from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,22 +33,4 @@
     {% endif %}
   </p>
 
-  <p>
-    {%- capture _platform -%}
-      <a href="https://jekyllrb.com" target="_blank" rel="noopener">Jekyll</a>
-    {%- endcapture -%}
-
-    {%- capture _theme -%}
-      <a
-        data-bs-toggle="tooltip"
-        data-bs-placement="top"
-        title="v{{ theme.version }}"
-        href="https://github.com/cotes2020/jekyll-theme-chirpy"
-        target="_blank"
-        rel="noopener"
-      >Chirpy</a>
-    {%- endcapture -%}
-
-    {{ site.data.locales[include.lang].meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}
-  </p>
 </footer>


### PR DESCRIPTION
## Summary

- Removes the "Powered by Jekyll using the Chirpy theme" line from the footer
- MIT license only requires copyright notice in source code, not in the UI — this is fine legally

## Test plan

- [ ] Footer shows only the copyright line (© 2014 – 2026 Srinivas Reddy Alluri)
- [ ] No layout shift or broken footer styling